### PR TITLE
Added support for Win32NT platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
       "browser",
       "blackberry10",
       "windows8",
-      "windows"
+      "windows",
+      "Win32NT"
     ]
   },
   "repository": {
@@ -39,8 +40,7 @@
     "cordova-ubuntu",
     "cordova-browser",
     "cordova-blackberry10",
-    "cordova-windows8",
-    "cordova-windows"
+    "cordova-windows8"
   ],
   "engines": {
       "cordova": ">=3.0"

--- a/plugin.xml
+++ b/plugin.xml
@@ -91,4 +91,11 @@
       <runs />
     </js-module>
   </platform>
+  <!-- Win32NT -->
+  <platform name="Win32NT">
+    <js-module src="www/windows/Smaato.js" name="Smaato1">
+      <merges target="window.Smaato" />
+      <runs />
+    </js-module>
+  </platform>
 </plugin>


### PR DESCRIPTION
Windows Phone Universal apps can be platform "windows" or "Win32NT"
